### PR TITLE
add bangkok,sanfrancisco2024

### DIFF
--- a/crawledEvents.json
+++ b/crawledEvents.json
@@ -1,4 +1,6 @@
 {
+  "bangkok": false,
+  "sanfrancisco2024": false,
   "singapore2024": false,
   "ethonline2024": false,
   "superhack2024": false,


### PR DESCRIPTION
This pull request includes a small change to the `crawledEvents.json` file. The change adds two new events, `bangkok` and `sanfrancisco2024`, to the list of crawled events.

* [`crawledEvents.json`](diffhunk://#diff-34ca128d703e06ae44a0ccb6ccf03f3c52331741fe1a3e72b9a3b4b0aa1bc1c0R2-R3): Added `bangkok` and `sanfrancisco2024` events to the list of crawled events.