### PR TITLE
📝 ドキュメント(crawledEvents.json): 新しいイベントのJSON構造を追加

### DIFF
--- a/crawledEvents.json
+++ b/crawledEvents.json
@@ -1,4 +1,6 @@
 {
+  "cannes": false,
+  "prague": false,
   "taipei": false,
   "trifecta-agents": false,
   "trifecta-tee": false,


### PR DESCRIPTION
イベントのJSON構造が更新され、cannes、prague、taipei、trifecta-agents、trifecta-teeの各イベントのステータスをfalseに設定しました。これにより、イベントのステータスを追跡できます。