### PR TITLE
MCPサーバーの検索機能をコマンドラインから手軽にテストできるスクリプトとドキュメント・実装の改善を行いました。

### DIFF
--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -94,10 +94,32 @@ npm run mcp:build
 
 ### ローカルでのテスト
 
+MCP サーバーの開発モード。
+
 ```bash
 cd mcp-server
 npm run dev
 ```
+
+検索機能のテスト。
+
+```bash
+# 基本的な検索（デフォルト5件）
+npm run test:search "NFTマーケットプレイス"
+
+# 結果数を指定して検索
+npm run test:search "DeFi プロトコル" 10
+
+# 英語での検索
+npm run test:search "blockchain gaming" 3
+```
+
+テストスクリプトの特徴。
+
+- コマンドライン引数で検索クエリを指定
+- 結果数の上限を任意で指定可能
+- Ollama を使用した埋め込みベクトル生成
+- エラー時の詳細なメッセージ表示
 
 ### 新しいツールの追加
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -16,7 +16,15 @@ The following environment variables must be set:
 
 - `QD_URL`: Qdrant server URL
 - `QD_API_KEY`: Qdrant API key for authentication
-- `NOMIC_API_KEY`: Nomic API key for generating embeddings
+- `NOMIC_API_KEY`: Nomic API key for generating embeddings (production only)
+- `NEXT_PUBLIC_ENVIRONMENT`: Set to "production" to use Nomic API, otherwise uses Ollama
+
+### Embedding Models
+
+- Development: Uses Ollama with `nomic-embed-text` model
+  - Make sure Ollama is running: `ollama serve`
+  - Pull the model if needed: `ollama pull nomic-embed-text`
+- Production: Uses Nomic API (requires NOMIC_API_KEY)
 
 ### Building
 
@@ -91,8 +99,31 @@ To use this MCP server with Claude Code or other MCP-compatible applications, ad
 
 ## Development
 
+### Running the MCP Server
+
 For development with hot reloading:
 
 ```bash
 npm run dev
 ```
+
+### Testing Search Functionality
+
+Test the search functionality with custom queries:
+
+```bash
+# Search with default limit (5 results)
+npm run test:search "NFT marketplace"
+
+# Search with custom limit
+npm run test:search "DeFi lending platform" 10
+
+# Search in Japanese
+npm run test:search "分散型金融" 3
+```
+
+The test script:
+- Accepts search query as the first argument
+- Optionally accepts result limit as the second argument
+- Shows embedding creation and search results
+- Provides detailed error messages for troubleshooting

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -10,13 +10,15 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test:search": "tsx src/test-search.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^0.5.0",
     "@qdrant/js-client-rest": "^1.11.0",
     "axios": "^1.7.7",
     "dotenv": "^16.4.5",
+    "ollama": "^0.5.8",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/mcp-server/src/test-search.ts
+++ b/mcp-server/src/test-search.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { config } from "dotenv";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { QdrantHandler, Project } from "./qdrantClient.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Load environment variables from parent directory
+config({ path: join(__dirname, "../../.env") });
+
+interface SearchOptions {
+  query: string;
+  limit?: number;
+}
+
+async function testSearch(options: SearchOptions): Promise<void> {
+  console.log("Testing MCP server functionality...\n");
+
+  try {
+    // Initialize handler
+    const handler = new QdrantHandler();
+
+    // Search parameters
+    const { query, limit = 5 } = options;
+    console.log(`Searching for: "${query}"`);
+    console.log(`Limit: ${limit}\n`);
+
+    // Create embedding
+    console.log("Creating embedding...");
+    const embedding = await handler.createEmbedding(query);
+    console.log(`✓ Embedding created (length: ${embedding.length})\n`);
+
+    // Search for similar projects
+    console.log("Searching for similar projects...");
+    const results: Project[] = await handler.searchSimilarProjects(
+      embedding,
+      limit,
+    );
+
+    if (results.length === 0) {
+      console.log("No results found. The database might be empty.");
+    } else {
+      console.log(`✓ Found ${results.length} similar projects:\n`);
+
+      results.forEach((project, index) => {
+        console.log(`${index + 1}. ${project.title}`);
+        console.log(
+          `   Description: ${project.description.substring(0, 100)}...`,
+        );
+        if (project.link) {
+          console.log(`   Link: ${project.link}`);
+        }
+        if (project.sourceCode) {
+          console.log(`   Source: ${project.sourceCode}`);
+        }
+        console.log("");
+      });
+    }
+  } catch (error: any) {
+    console.error("Error during test:", error.message);
+    if (
+      error.message.includes("403") ||
+      error.message.includes("authentication")
+    ) {
+      console.error(
+        "\nAuthentication failed. Please check your API keys in the .env file.",
+      );
+    } else if (error.message.includes("Ollama")) {
+      console.error("\nMake sure Ollama is running: ollama serve");
+    }
+  }
+}
+
+// Parse command line arguments
+function parseArgs(): SearchOptions {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0) {
+    console.error('Usage: npm run test:search "<query>" [limit]');
+    console.error('Example: npm run test:search "NFT marketplace" 10');
+    process.exit(1);
+  }
+
+  const query = args[0];
+  const limit = args[1] ? parseInt(args[1], 10) : undefined;
+
+  if (limit && isNaN(limit)) {
+    console.error("Error: Limit must be a number");
+    process.exit(1);
+  }
+
+  return { query, limit };
+}
+
+// Main execution
+const options = parseArgs();
+testSearch(options).catch(console.error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "@qdrant/js-client-rest": "^1.11.0",
         "axios": "^1.7.7",
         "dotenv": "^16.4.5",
+        "ollama": "^0.5.8",
         "zod": "^3.22.4"
       },
       "bin": {


### PR DESCRIPTION
### 概要
MCPサーバーの検索機能をコマンドラインから手軽にテストできるスクリプトとドキュメント・実装の改善を行いました。

### 主な変更点
- `mcp-server/src/test-search.ts`  
  検索クエリ・件数をコマンドライン引数で指定し、ローカル/プロダクション環境に応じてOllamaまたはNomic APIで埋め込み生成→Qdrant検索→結果を表示するテストスクリプトを追加
- `mcp-server/package.json`  
  `test:search`スクリプト・Ollama依存パッケージを追加
- `mcp-server/src/qdrantClient.ts`  
  開発環境ではOllama、プロダクションではNomic APIを自動切り替えするよう埋め込み生成ロジックをリファクタ
- `mcp-server/README.md`・`docs/mcp-setup.md`  
  テストスクリプトの使い方、埋め込み生成の切り替え仕様、Ollamaのセットアップ方法などを追記
- その他、エラー時の詳細なメッセージ表示や、柔軟な検索件数指定など利便性を向上

### 動作確認
- `npm run test:search "検索クエリ" [件数]` で、ローカル/本番どちらの環境でも埋め込み生成と検索が正しく動作することを確認