### PR TITLE
issue 236 QdrantHandlerのエラー処理に関する統合テストを拡充し、テストメッセージの定数化を行いました

### DIFF
--- a/mcp-server/src/testConstants/errorMessages.ts
+++ b/mcp-server/src/testConstants/errorMessages.ts
@@ -1,0 +1,28 @@
+/**
+ * Common error messages used in tests for consistent error checking
+ * These messages should match the actual error messages thrown by the QdrantHandler
+ */
+
+export const ERROR_MESSAGES = {
+  // Configuration errors
+  NOMIC_API_KEY_MISSING: "NOMIC_API_KEY environment variable is not set",
+  NOMIC_API_KEY_MISSING_PRODUCTION:
+    "Embedding failed: Configuration error. Please contact support.",
+  INVALID_PROVIDER: /Unsupported embedding provider: .+/,
+
+  // Ollama errors
+  OLLAMA_NOT_RUNNING_DEV:
+    /Ollama failed: Ollama is not running at .+\. Please start Ollama with: 'ollama serve' and pull the model with: 'ollama pull .+'/,
+  OLLAMA_NOT_RUNNING_PROD:
+    "Ollama failed: Service is not available. Please contact support.",
+
+  // HTTP errors
+  AUTH_FAILED_403: /Embedding failed: 403: authentication failed/,
+  UNAUTHORIZED_401: /Embedding failed: 401: unauthorized/,
+  RATE_LIMIT_429: /Embedding failed: 429: rate limit exceeded/,
+
+  // Generic errors
+  EMBEDDING_FAILED: "Embedding failed:",
+  OLLAMA_FAILED: "Ollama failed:",
+  UNKNOWN_ERROR: "Unknown error",
+} as const;


### PR DESCRIPTION
## 概要

QdrantHandlerのエラー処理に関する統合テストを拡充し、テストメッセージの定数化を行いました。

## 変更内容

- `mcp-server/src/__tests__/qdrantHandler.integration.test.ts` のテストケースを追加・修正
    - エラー発生時のメッセージ検証を強化
    - OllamaプロバイダーやHTTPエラーのテストパターンを追加
- `mcp-server/src/testConstants/errorMessages.ts` を新規作成し、エラーメッセージを定数として管理

## 背景・目的

エラー発生時のメッセージが一貫しているかをテストで検証できるようにすることで、今後のリファクタリングや機能追加時の品質を担保します。また、テストコードの可読性・保守性向上を図ります。

## 動作確認

- 追加・修正したテストがすべてパスすることを確認しました

## 関連Issue

- #236

## その他

ご確認のほどよろしくお願いいたします。