### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/delete-workflow-history.yml
+++ b/.github/workflows/delete-workflow-history.yml
@@ -1,4 +1,6 @@
 name: Delete workflow history
+permissions:
+  actions: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/susumutomita/Hackathon-AI/security/code-scanning/2](https://github.com/susumutomita/Hackathon-AI/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the workflow deletes workflow runs, it requires `actions: write` permission. Other permissions can be set to `none` or omitted for minimal privilege. The best practice is to add the `permissions` block at the job level (for `delete-history`), but adding it at the workflow root is also acceptable if only one job exists. Edit `.github/workflows/delete-workflow-history.yml` to add:

```yaml
permissions:
  actions: write
```

at the top level (after `name:` and before `on:`), or under the `delete-history` job. This ensures the workflow only has the permissions it needs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
