### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 on:
   push:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/susumutomita/Hackathon-AI/security/code-scanning/3](https://github.com/susumutomita/Hackathon-AI/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to restrict the permissions of the `GITHUB_TOKEN` to the minimum required. Since none of the steps in the workflow require write access to repository contents or other resources, the best fix is to set `contents: read` at the workflow level (top-level, just below the `name` and before `on`). This will apply to all jobs in the workflow unless overridden. No additional imports or definitions are needed; simply add the block in the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
