### PR TITLE
🐛 修正(mcp-server/README.md): 依存関係のインストールコマンドをnpmからpnpmに変更

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 frozen-lockfile=false
 auto-install-peers=true
 strict-peer-dependencies=false
+ignore-workspace-root-check=true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # デフォルトターゲットはhelp
 default: help
 
-# npm run を実行するターゲット
+# pnpm run を実行するターゲット
 NPM_RUN_TARGETS = clean lint lint_text format format_check test dev build
 
 $(NPM_RUN_TARGETS):
@@ -33,7 +33,7 @@ help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  install         Install npm packages"
+	@echo "  install         Install pnpm packages"
 	@echo "  clean           Clean the project"
 	@echo "  setup_husky     Setup Husky"
 	@echo "  lint            Run linter"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ graph TB
 ### Prerequisites
 
 - Node.js (version 14.x or above)
-- npm or yarn
+- pnpm
 - Ollama (for running the LLM locally)
 
 ### Installation Steps

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -10,14 +10,14 @@
 
 ```bash
 # MCPサーバーの依存関係をインストール
-npm run mcp:install
+pnpm run mcp:install
 ```
 
 ### 2. MCPサーバーのビルド
 
 ```bash
 # MCPサーバーをビルド
-npm run mcp:build
+pnpm run mcp:build
 ```
 
 ### 3. 環境変数の設定
@@ -81,7 +81,7 @@ npm run mcp:build
 ### MCPサーバーが起動しない
 
 1. 環境変数が正しく設定されているか確認
-2. ビルドが成功しているか確認：`cd mcp-server && npm run build`
+2. ビルドが成功しているか確認：`cd mcp-server && pnpm run build`
 3. ログを確認：MCP サーバーは stderr にログを出力
 
 ### 検索結果が返ってこない
@@ -98,20 +98,20 @@ MCP サーバーの開発モード。
 
 ```bash
 cd mcp-server
-npm run dev
+pnpm run dev
 ```
 
 検索機能のテスト。
 
 ```bash
 # 基本的な検索（デフォルト5件）
-npm run test:search "NFTマーケットプレイス"
+pnpm run test:search "NFTマーケットプレイス"
 
 # 結果数を指定して検索
-npm run test:search "DeFi プロトコル" 10
+pnpm run test:search "DeFi プロトコル" 10
 
 # 英語での検索
-npm run test:search "blockchain gaming" 3
+pnpm run test:search "blockchain gaming" 3
 ```
 
 テストスクリプトの特徴。

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -44,8 +44,8 @@ The server supports two embedding providers:
 From the mcp-server directory:
 
 ```bash
-npm install
-npm run build
+pnpm install
+pnpm run build
 ```
 
 ### Running
@@ -53,7 +53,7 @@ npm run build
 The server runs on stdio and can be integrated with Claude or other MCP-compatible applications.
 
 ```bash
-npm start
+pnpm start
 ```
 
 ## Available Tools
@@ -140,7 +140,7 @@ For using Ollama (local LLM):
 For development with hot reloading:
 
 ```bash
-npm run dev
+pnpm run dev
 ```
 
 ### Testing Search Functionality
@@ -149,13 +149,13 @@ Test the search functionality with custom queries:
 
 ```bash
 # Search with default limit (5 results)
-npm run test:search "NFT marketplace"
+pnpm run test:search "NFT marketplace"
 
 # Search with custom limit
-npm run test:search "DeFi lending platform" 10
+pnpm run test:search "DeFi lending platform" 10
 
 # Search in Japanese
-npm run test:search "分散型金融" 3
+pnpm run test:search "分散型金融" 3
 ```
 
 The test script:


### PR DESCRIPTION
## pnpm対応に関するドキュメント・設定修正

### 概要
- プロジェクトの依存管理をpnpmに統一するため、各種ドキュメント・設定ファイルを修正しました。

### 主な変更点
- `.npmrc`に`ignore-workspace-root-check=true`を追加し、pnpm利用時の警告を回避
- `Makefile`内の説明文やターゲット名をnpm→pnpmに修正
- `README.md`、`docs/mcp-setup.md`、`mcp-server/README.md`のインストール・ビルド・実行コマンドをnpm/yarnからpnpmへ統一

### 背景・目的
- 依存関係の管理をpnpmに一本化したことに伴い、npm/yarn記述のままになっていたドキュメントやMakefile説明を修正し、開発者が混乱しないようにしました。

### レビュー観点
- ドキュメントやMakefileのコマンド表記にnpm/yarnが残っていないか
- pnpmでのセットアップ・ビルド・テストが問題なく動作するか

ご確認よろしくお願いいたします。