### PR TITLE
add updatater

### DIFF
--- a/docs/auto-crawl-setup.md
+++ b/docs/auto-crawl-setup.md
@@ -1,0 +1,122 @@
+# ETHGlobal Events 自動クロール設定
+
+## 概要
+
+このシステムは、ETHGlobal のイベントを自動的に検出し、新しいイベントがあれば自動的にクロールしてデータベースに追加します。
+
+## 仕組み
+
+1. イベント検出: ETHGlobal のサイトから最新のイベント一覧を取得
+2. プルリクエスト作成: 新しいイベントが見つかった場合、自動的に PR を作成
+3. AI レビュー: Claude AI が自動的に PR をレビュー
+4. データベース更新: プロジェクトの重複を防ぐ upsert 処理で DB を更新
+5. 定期実行: GitHub Actions で毎日自動実行
+
+## 主な改善点
+
+### 1. プルリクエスト方式
+
+- 直接コミットではなく PR を作成することで、変更内容を確認可能
+- AI による自動レビューで品質を保証
+- 手動で有効化するイベントを選択可能
+
+### 2. データベース重複対策
+
+- プロジェクトのリンクを基にユニーク ID を生成
+- 既存のプロジェクトは更新（upsert）され、重複登録を防止
+- 最終更新日時を記録
+
+## セットアップ
+
+### 1. 環境変数の設定
+
+GitHub Secrets に以下の環境変数を設定してください。
+
+- `CRON_SECRET`: API エンドポイントへのアクセストークン
+- `QD_URL`: Qdrant データベースの URL
+- `QD_API_KEY`: Qdrant API キー
+- `NOMIC_API_KEY`: Nomic Embeddings API キー
+
+### 2. Vercel デプロイ設定
+
+Vercel に同じ環境変数を設定してください。
+
+### 3. 実行方法の選択
+
+#### オプション1: GitHub Actions内で直接実行（推奨）
+
+現在の実装では、GitHub Actions 内で直接スクリプトを実行します。
+追加の設定は不要です。
+
+#### オプション2: Vercel Webhookを使用
+
+`crawledEvents.json`が更新されたときに、Vercel でクロールを実行したい場合。
+
+1. Vercel Webhook URL を`VERCEL_WEBHOOK_URL` secret に設定
+2. `.github/workflows/crawl-enabled-events.yml`が自動的にトリガー
+
+## 使用方法
+
+### 自動実行
+
+- 毎日 UTC 0 時（日本時間 9 時）に自動実行
+- GitHub Actions のワークフローページから手動実行も可能
+
+### 手動実行
+
+1. イベント更新のみ:
+
+   ```bash
+   curl -X POST https://your-app.vercel.app/api/update-events \
+     -H "Authorization: Bearer YOUR_CRON_SECRET"
+   ```
+
+2. イベント更新とクロール:
+
+   ```bash
+   curl -X POST https://your-app.vercel.app/api/auto-crawl \
+     -H "Authorization: Bearer YOUR_CRON_SECRET"
+   ```
+
+### イベントの有効化
+
+新しいイベントが検出されると、`crawledEvents.json`に`false`として追加されます。
+クロールしたいイベントは手動で`true`に変更してください。
+
+```json
+{
+  "unite": true,  // このイベントはクロールされる
+  "newevent": false  // このイベントはクロールされない
+}
+```
+
+## APIエンドポイント
+
+### `/api/update-events`
+
+- 最新のイベント一覧を取得し、新しいイベントを`crawledEvents.json`に追加
+
+### `/api/auto-crawl`
+
+- イベントの更新とクロールを一括実行
+
+### `/api/crawl`
+
+- 手動クロール用（開発環境のみ）
+
+## トラブルシューティング
+
+### イベントが更新されない
+
+- ETHGlobal のサイト構造が変更されている可能性
+- `src/lib/eventUpdater.ts`のセレクタを確認
+
+### クロールが失敗する
+
+- Qdrant データベースの接続を確認してください
+- 環境変数が正しく設定されているか確認してください
+
+### GitHub Actionsが失敗する
+
+- Secrets が正しく設定されているか確認してください
+- ワークフローのログを確認してエラーメッセージを特定してください

--- a/src/lib/eventUpdater.ts
+++ b/src/lib/eventUpdater.ts
@@ -1,0 +1,118 @@
+import axios from "axios";
+import * as cheerio from "cheerio";
+import fs from "fs";
+import path from "path";
+import logger from "@/lib/logger";
+
+const eventsFilePath = path.join(process.cwd(), "crawledEvents.json");
+
+interface EventsMap {
+  [key: string]: boolean;
+}
+
+export async function fetchLatestEvents(): Promise<string[]> {
+  try {
+    logger.info("Fetching latest events from ETHGlobal...");
+    const response = await axios.get("https://ethglobal.com/events");
+    const $ = cheerio.load(response.data);
+
+    const events: string[] = [];
+
+    // ETHGlobalのイベントページからイベントIDを抽出
+    $('a[href^="/events/"]').each((_, element) => {
+      const href = $(element).attr("href");
+      if (href) {
+        const eventId = href.split("/events/")[1];
+        if (eventId && !eventId.includes("/")) {
+          events.push(eventId);
+        }
+      }
+    });
+
+    // 重複を削除
+    const uniqueEvents = [...new Set(events)];
+    logger.info(`Found ${uniqueEvents.length} events`);
+
+    return uniqueEvents;
+  } catch (error) {
+    logger.error("Failed to fetch latest events:", error);
+    throw error;
+  }
+}
+
+export async function loadCurrentEvents(): Promise<EventsMap> {
+  try {
+    if (fs.existsSync(eventsFilePath)) {
+      const rawData = fs.readFileSync(eventsFilePath, "utf-8");
+      return JSON.parse(rawData);
+    }
+    return {};
+  } catch (error) {
+    logger.error("Failed to load current events:", error);
+    return {};
+  }
+}
+
+export async function updateEventsFile(newEvents: string[]): Promise<{
+  added: string[];
+  total: number;
+}> {
+  try {
+    const currentEvents = await loadCurrentEvents();
+    const added: string[] = [];
+
+    // 新しいイベントを追加（デフォルトでfalse）
+    for (const event of newEvents) {
+      if (!(event in currentEvents)) {
+        currentEvents[event] = false;
+        added.push(event);
+        logger.info(`Added new event: ${event}`);
+      }
+    }
+
+    if (added.length > 0) {
+      // ファイルを更新
+      fs.writeFileSync(
+        eventsFilePath,
+        JSON.stringify(currentEvents, null, 2) + "\n",
+        "utf-8",
+      );
+      logger.info(`Updated events file with ${added.length} new events`);
+    } else {
+      logger.info("No new events found");
+    }
+
+    return {
+      added,
+      total: Object.keys(currentEvents).length,
+    };
+  } catch (error) {
+    logger.error("Failed to update events file:", error);
+    throw error;
+  }
+}
+
+export async function checkAndUpdateEvents(): Promise<{
+  success: boolean;
+  added: string[];
+  total: number;
+  error?: string;
+}> {
+  try {
+    const latestEvents = await fetchLatestEvents();
+    const result = await updateEventsFile(latestEvents);
+
+    return {
+      success: true,
+      ...result,
+    };
+  } catch (error: any) {
+    logger.error("Event update process failed:", error);
+    return {
+      success: false,
+      added: [],
+      total: 0,
+      error: error.message || "Unknown error",
+    };
+  }
+}

--- a/src/pages/api/auto-crawl.ts
+++ b/src/pages/api/auto-crawl.ts
@@ -1,0 +1,51 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { checkAndUpdateEvents } from "@/lib/eventUpdater";
+import { crawlEthGlobalShowcase } from "@/lib/crawler";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  // セキュリティ: GitHub Actionsからのアクセスのみ許可
+  const authHeader = req.headers.authorization;
+  const expectedToken = process.env.CRON_SECRET;
+
+  if (expectedToken && authHeader !== `Bearer ${expectedToken}`) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    // Step 1: 最新のイベントを取得して更新
+    const updateResult = await checkAndUpdateEvents();
+
+    if (!updateResult.success) {
+      return res.status(500).json({
+        error: "Failed to update events",
+        details: updateResult.error,
+      });
+    }
+
+    // Step 2: 有効化されているイベントをクロール
+    const projects = await crawlEthGlobalShowcase();
+
+    res.status(200).json({
+      message: "Auto crawl completed successfully",
+      eventsUpdate: {
+        added: updateResult.added,
+        total: updateResult.total,
+      },
+      crawlResult: {
+        projectsCount: projects.length,
+      },
+    });
+  } catch (error: any) {
+    res.status(500).json({
+      error: "Auto crawl failed",
+      details: error.message || "An unknown error occurred",
+    });
+  }
+}

--- a/src/pages/api/update-events.ts
+++ b/src/pages/api/update-events.ts
@@ -1,0 +1,41 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { checkAndUpdateEvents } from "@/lib/eventUpdater";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  // セキュリティ: GitHub Actionsからのアクセスのみ許可
+  const authHeader = req.headers.authorization;
+  const expectedToken = process.env.CRON_SECRET;
+
+  if (expectedToken && authHeader !== `Bearer ${expectedToken}`) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    const result = await checkAndUpdateEvents();
+
+    if (result.success) {
+      res.status(200).json({
+        message: "Events updated successfully",
+        added: result.added,
+        total: result.total,
+      });
+    } else {
+      res.status(500).json({
+        error: "Failed to update events",
+        details: result.error,
+      });
+    }
+  } catch (error: any) {
+    res.status(500).json({
+      error: "Internal server error",
+      details: error.message || "An unknown error occurred",
+    });
+  }
+}


### PR DESCRIPTION
## ETHGlobalイベント自動監視・クロール機能の追加

### 概要
- ETHGlobalのイベント新規追加を自動検出し、クロール・データベース登録まで自動化する新機能を実装しました。
- 毎日自動でイベント一覧を取得し、差分があればPR作成やAIレビュー、DB upsertまで一元管理できます。

### 主な変更点
- `docs/auto-crawl-setup.md`: 自動クロールのセットアップ・運用方法ドキュメントを追加
- `src/lib/eventUpdater.ts`: ETHGlobalイベント一覧の取得・差分検出・ファイル更新処理を実装
- `src/lib/qdrantHandler.ts`/`test.ts`: DB登録(upsert)処理をイベント単位で重複なく行うよう改善
- `src/pages/api/auto-crawl.ts`: イベント更新＋クロールを一括実行するAPI追加
- `src/pages/api/update-events.ts`: イベント一覧の更新のみを行うAPI追加

### 背景・目的
- ハッカソンイベントの自動検出・登録を行うことで、運用負荷・手動作業を削減し、常に最新のイベント情報を活用できる体制を目指しました。
- PR方式＋AIレビューにより、品質担保や手動での有効化フローも維持できます。

### レビュー観点
- イベント検出・DB登録の重複防止ロジック
- セキュリティ（APIトークン/認証ヘッダ等）
- ドキュメント記載内容と実装の整合性
- 既存機能への影響有無

ご確認よろしくお願いいたします。