### PR TITLE
embed用モデルの環境変数（OLLAMA_EMBED_MODEL）が優先されるように修正しました。これにより、embedding用途と通常の推論用途で異なるモデルを柔軟に指定できます。

### DIFF
--- a/src/adapters/ollama.adapter.ts
+++ b/src/adapters/ollama.adapter.ts
@@ -34,8 +34,12 @@ export class OllamaAdapter implements EmbeddingProvider {
   private readonly timeout?: number;
 
   constructor(config?: OllamaConfig) {
+    // Use OLLAMA_EMBED_MODEL specifically for embeddings, fallback to OLLAMA_MODEL, then default
     this.model =
-      config?.model || process.env.OLLAMA_MODEL || "nomic-embed-text";
+      config?.model ||
+      process.env.OLLAMA_EMBED_MODEL ||
+      process.env.OLLAMA_MODEL ||
+      "nomic-embed-text";
     this.baseUrl = config?.baseUrl || process.env.OLLAMA_URL;
     this.timeout = config?.timeout;
   }


### PR DESCRIPTION
## 概要
embed用モデルの環境変数（OLLAMA_EMBED_MODEL）が優先されるように修正しました。これにより、embedding用途と通常の推論用途で異なるモデルを柔軟に指定できます。

## 主な変更点
- OLLAMA_EMBED_MODEL → OLLAMA_MODEL → デフォルト（nomic-embed-text）の順にモデルを選択するように修正
- コード内コメントも追記し、意図を明確化

## 背景・目的
embedding用途とchat用途で異なるOllamaモデルを使いたい場合、環境変数で柔軟に切り替えられるようにすることで運用性・テスト性が向上します。

## レビュー観点
- モデルの優先順位の実装に漏れや不備がないか
- 既存の他用途への影響
- ドキュメントやコメントの分かりやすさ

ご確認よろしくお願いします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the logic for selecting the default embedding model to prioritize a new environment variable for improved configuration flexibility. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->