### PR TITLE
fix duplicate records

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "mcp:build": "cd mcp-server && pnpm run build",
-    "mcp:install": "cd mcp-server && pnpm install"
+    "mcp:install": "cd mcp-server && pnpm install",
+    "remove-duplicates": "tsx src/scripts/removeDuplicates.ts"
   },
   "keywords": [],
   "author": "Susumu Tomita <oyter880@gmail.com> (https://susumutomita.netlify.app/)",
@@ -65,7 +66,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
-    "dotenv": "^16.4.5",
+    "dotenv": "^16.6.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.6",
     "husky": "^9.1.4",
@@ -83,6 +84,7 @@
     "textlint-rule-preset-ja-spacing": "^2.2.0",
     "textlint-rule-preset-ja-technical-writing": "^10.0.1",
     "textlint-rule-spellcheck-tech-word": "^5.0.0",
+    "tsx": "^4.7.0",
     "vitest": "^3.2.4"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
       dotenv:
-        specifier: ^16.4.5
+        specifier: ^16.6.1
         version: 16.6.1
       eslint:
         specifier: ^8
@@ -171,6 +171,9 @@ importers:
       textlint-rule-spellcheck-tech-word:
         specifier: ^5.0.0
         version: 5.0.0(textlint@14.8.4)
+      tsx:
+        specifier: ^4.7.0
+        version: 4.20.3
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.17.0)(@vitest/ui@3.2.4)(jiti@1.21.7)(jsdom@26.1.0)(tsx@4.20.3)(yaml@2.8.0)

--- a/src/lib/qdrantHandler.test.ts
+++ b/src/lib/qdrantHandler.test.ts
@@ -498,20 +498,13 @@ describe("QdrantHandler", () => {
       );
 
       expect(result).toBeNull();
+      // The new implementation calls findExistingProject which first tries to find by link
+      // by getting all projects and normalizing links
       expect(mockQdrantClient.scroll).toHaveBeenCalledWith(
         "eth_global_showcase",
         {
-          filter: {
-            must: [
-              {
-                key: "link",
-                match: {
-                  value: "https://nonexistent.com",
-                },
-              },
-            ],
-          },
-          limit: 1,
+          limit: 10000,
+          with_payload: true,
         },
       );
     });
@@ -528,8 +521,9 @@ describe("QdrantHandler", () => {
       );
 
       expect(result).toBeNull();
+      // The new implementation logs a different error message
       expect(logger.error).toHaveBeenCalledWith(
-        "Failed to find project by link:",
+        "Failed to find existing project:",
         expect.any(Error),
       );
     });

--- a/src/scripts/removeDuplicates.ts
+++ b/src/scripts/removeDuplicates.ts
@@ -1,0 +1,214 @@
+import "dotenv/config"; // .envファイルを読み込む
+import { QdrantClient } from "@qdrant/js-client-rest";
+import { getValidatedEnv } from "@/lib/env";
+import logger from "@/lib/logger";
+
+interface ProjectPayload {
+  title: string;
+  projectDescription?: string;
+  howItsMade?: string;
+  sourceCode?: string;
+  link?: string;
+  hackathon?: string;
+  lastUpdated?: string;
+}
+
+interface ProjectPoint {
+  id: string | number;
+  payload: ProjectPayload;
+  vector?: number[];
+}
+
+async function removeDuplicates() {
+  const env = getValidatedEnv();
+  const client = new QdrantClient({
+    url: env.QD_URL,
+    apiKey: env.QD_API_KEY,
+  });
+
+  try {
+    logger.info("重複データの検出を開始します...");
+
+    // すべてのデータを取得
+    const scrollResult = await client.scroll("eth_global_showcase", {
+      limit: 10000,
+      with_payload: true,
+    });
+
+    const points = scrollResult.points as unknown as ProjectPoint[];
+    logger.info(`総データ数: ${points.length}`);
+
+    // リンクベースで重複を検出
+    const linkMap = new Map<string, ProjectPoint[]>();
+    const titleHackathonMap = new Map<string, ProjectPoint[]>();
+
+    for (const point of points) {
+      // リンクによるグルーピング
+      if (point.payload?.link) {
+        // リンクの正規化（末尾スラッシュを削除、小文字化）
+        const normalizedLink = point.payload.link
+          .toLowerCase()
+          .replace(/\/$/, "")
+          .replace(/^https?:\/\//, ""); // プロトコルも削除
+
+        if (!linkMap.has(normalizedLink)) {
+          linkMap.set(normalizedLink, []);
+        }
+        linkMap.get(normalizedLink)!.push(point);
+      }
+
+      // タイトル + ハッカソンによるグルーピング（リンクがない場合の重複検出）
+      if (point.payload?.title && point.payload?.hackathon) {
+        const key = `${point.payload.title.toLowerCase().trim()}_${point.payload.hackathon.toLowerCase().trim()}`;
+        if (!titleHackathonMap.has(key)) {
+          titleHackathonMap.set(key, []);
+        }
+        titleHackathonMap.get(key)!.push(point);
+      }
+    }
+
+    const duplicatesToDelete: (string | number)[] = [];
+    const processedIds = new Set<string | number>();
+
+    // リンクベースの重複処理
+    logger.info("\n=== リンクベースの重複検出 ===");
+    for (const [link, duplicatePoints] of linkMap.entries()) {
+      if (duplicatePoints.length > 1) {
+        logger.info(`\n重複発見 (リンク: ${link}):`);
+
+        // 最新のデータを保持（lastUpdatedが最新、またはIDが最小のもの）
+        const sortedPoints = duplicatePoints.sort((a, b) => {
+          // lastUpdatedで比較
+          if (a.payload.lastUpdated && b.payload.lastUpdated) {
+            return (
+              new Date(b.payload.lastUpdated).getTime() -
+              new Date(a.payload.lastUpdated).getTime()
+            );
+          }
+          // lastUpdatedがない場合はIDで比較（小さい方を保持）
+          return String(a.id).localeCompare(String(b.id));
+        });
+
+        const keepPoint = sortedPoints[0];
+        logger.info(
+          `  保持: ID=${keepPoint.id}, Title="${keepPoint.payload.title}", Hackathon="${keepPoint.payload.hackathon}"`,
+        );
+        processedIds.add(keepPoint.id);
+
+        // 残りは削除対象
+        for (let i = 1; i < sortedPoints.length; i++) {
+          const deletePoint = sortedPoints[i];
+          if (!processedIds.has(deletePoint.id)) {
+            duplicatesToDelete.push(deletePoint.id);
+            processedIds.add(deletePoint.id);
+            logger.info(
+              `  削除: ID=${deletePoint.id}, Title="${deletePoint.payload.title}", Hackathon="${deletePoint.payload.hackathon}"`,
+            );
+          }
+        }
+      }
+    }
+
+    // タイトル+ハッカソンベースの重複処理（リンクがない場合）
+    logger.info("\n=== タイトル+ハッカソンベースの重複検出 ===");
+    for (const [key, duplicatePoints] of titleHackathonMap.entries()) {
+      // 既に処理済みのポイントをフィルタリング
+      const unprocessedPoints = duplicatePoints.filter(
+        (p) => !processedIds.has(p.id),
+      );
+
+      if (unprocessedPoints.length > 1) {
+        const [title, hackathon] = key.split("_");
+        logger.info(
+          `\n重複発見 (タイトル: "${title}", ハッカソン: "${hackathon}"):`,
+        );
+
+        // 最新のデータを保持
+        const sortedPoints = unprocessedPoints.sort((a, b) => {
+          // lastUpdatedで比較
+          if (a.payload.lastUpdated && b.payload.lastUpdated) {
+            return (
+              new Date(b.payload.lastUpdated).getTime() -
+              new Date(a.payload.lastUpdated).getTime()
+            );
+          }
+          // より詳細な情報を持つものを優先
+          const aScore =
+            (a.payload.projectDescription?.length || 0) +
+            (a.payload.howItsMade?.length || 0) +
+            (a.payload.sourceCode ? 100 : 0) +
+            (a.payload.link ? 50 : 0);
+          const bScore =
+            (b.payload.projectDescription?.length || 0) +
+            (b.payload.howItsMade?.length || 0) +
+            (b.payload.sourceCode ? 100 : 0) +
+            (b.payload.link ? 50 : 0);
+          return bScore - aScore;
+        });
+
+        const keepPoint = sortedPoints[0];
+        logger.info(
+          `  保持: ID=${keepPoint.id}, Link="${keepPoint.payload.link || "なし"}"`,
+        );
+        processedIds.add(keepPoint.id);
+
+        // 残りは削除対象
+        for (let i = 1; i < sortedPoints.length; i++) {
+          const deletePoint = sortedPoints[i];
+          if (!processedIds.has(deletePoint.id)) {
+            duplicatesToDelete.push(deletePoint.id);
+            processedIds.add(deletePoint.id);
+            logger.info(
+              `  削除: ID=${deletePoint.id}, Link="${deletePoint.payload.link || "なし"}"`,
+            );
+          }
+        }
+      }
+    }
+
+    logger.info(`\n=== 削除サマリー ===`);
+    logger.info(`削除対象の重複データ数: ${duplicatesToDelete.length}`);
+    logger.info(
+      `保持するデータ数: ${points.length - duplicatesToDelete.length}`,
+    );
+
+    if (duplicatesToDelete.length > 0) {
+      logger.info("\n重複データを削除しています...");
+
+      // バッチで削除（一度に大量のIDを削除しないように）
+      const batchSize = 100;
+      for (let i = 0; i < duplicatesToDelete.length; i += batchSize) {
+        const batch = duplicatesToDelete.slice(i, i + batchSize);
+        await client.delete("eth_global_showcase", {
+          wait: true,
+          points: batch,
+        });
+        logger.info(
+          `削除進捗: ${Math.min(i + batchSize, duplicatesToDelete.length)}/${duplicatesToDelete.length}`,
+        );
+      }
+
+      logger.info("重複データの削除が完了しました！");
+    } else {
+      logger.info("重複データは見つかりませんでした。");
+    }
+  } catch (error) {
+    logger.error("重複削除処理中にエラーが発生しました:", error);
+    throw error;
+  }
+}
+
+// スクリプトを実行
+if (require.main === module) {
+  removeDuplicates()
+    .then(() => {
+      logger.info("処理が正常に完了しました");
+      process.exit(0);
+    })
+    .catch((error) => {
+      logger.error("エラーが発生しました:", error);
+      process.exit(1);
+    });
+}
+
+export { removeDuplicates };

--- a/src/scripts/testQdrantConnection.ts
+++ b/src/scripts/testQdrantConnection.ts
@@ -1,0 +1,56 @@
+import "dotenv/config"; // .envファイルを読み込む
+import { QdrantClient } from "@qdrant/js-client-rest";
+import { getValidatedEnv } from "@/lib/env";
+
+async function testConnection() {
+  const env = getValidatedEnv();
+  console.log("Qdrant URL:", env.QD_URL);
+  console.log("API Key:", env.QD_API_KEY ? "Set (hidden)" : "Not set");
+
+  const client = new QdrantClient({
+    url: env.QD_URL,
+    apiKey: env.QD_API_KEY,
+    timeout: 10000, // 10秒のタイムアウト
+  });
+
+  try {
+    console.log("Attempting to connect to Qdrant...");
+    const collections = await client.getCollections();
+    console.log("Successfully connected to Qdrant!");
+    console.log(
+      "Available collections:",
+      collections.collections.map((c) => c.name),
+    );
+
+    // eth_global_showcaseコレクションの情報を取得
+    try {
+      const collectionInfo = await client.getCollection("eth_global_showcase");
+      console.log("\nCollection 'eth_global_showcase' info:");
+      console.log("- Points count:", collectionInfo.points_count);
+      console.log("- Vectors size:", collectionInfo.config?.params?.vectors);
+    } catch (error) {
+      console.log("Collection 'eth_global_showcase' not found");
+    }
+  } catch (error: any) {
+    console.error("Failed to connect to Qdrant:");
+    console.error("Error message:", error.message);
+    if (error.cause) {
+      console.error("Error cause:", error.cause);
+    }
+    if (error.response) {
+      console.error("Response status:", error.response.status);
+      console.error("Response data:", error.response.data);
+    }
+  }
+}
+
+if (require.main === module) {
+  testConnection()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error("Unexpected error:", error);
+      process.exit(1);
+    });
+}
+
+export { testConnection };


### PR DESCRIPTION
## 概要

Qdrantコレクションにおける重複レコードの検出・削除機能を追加し、既存のプロジェクト検索ロジックも強化しました。これにより、同一リンクやタイトル＋ハッカソンの重複データが自動的に整理され、データの一貫性が向上します。

## 主な変更点

- `removeDuplicates.ts`スクリプトを新規追加
  - リンクまたはタイトル＋ハッカソンの重複レコードを自動的に検出し、最新または情報量の多いものを残して他を削除
  - 削除進捗や保持・削除の詳細をログ出力
- QdrantHandlerの重複判定ロジックを改善
  - `findExistingProject`でリンクの正規化・タイトル＋ハッカソンの組み合わせによる検索に対応
  - 既存エラー時のログも改善
- テスト用スクリプト`testQdrantConnection.ts`を追加
  - Qdrantへの接続確認やコレクション情報の取得が容易に
- テスト・依存パッケージの調整
  - テストコードの修正・追加
  - `tsx`や`dotenv`バージョンアップ
  - `remove-duplicates`コマンドをpackage.jsonに追加

ご確認よろしくお願いいたします。