### PR TITLE
add unite

### DIFF
--- a/crawledEvents.json
+++ b/crawledEvents.json
@@ -1,4 +1,5 @@
 {
+  "unite": false,
   "cannes": false,
   "prague": false,
   "taipei": false,

--- a/src/scripts/testEmbedding.ts
+++ b/src/scripts/testEmbedding.ts
@@ -1,0 +1,45 @@
+import "dotenv/config";
+import { OllamaAdapter } from "@/adapters/ollama.adapter";
+
+async function testEmbedding() {
+  try {
+    console.log("Testing Ollama embedding creation...");
+
+    const adapter = new OllamaAdapter();
+    const testText = "This is a test message for embedding creation";
+
+    console.log("Creating embedding for:", testText);
+    const embedding = await adapter.createEmbedding(testText);
+
+    console.log("✅ Success! Embedding created");
+    console.log("Embedding dimensions:", embedding.length);
+    console.log("First 5 values:", embedding.slice(0, 5));
+
+    return true;
+  } catch (error: any) {
+    console.error("❌ Failed to create embedding:", error.message);
+    if (error.cause) {
+      console.error("Cause:", error.cause);
+    }
+    return false;
+  }
+}
+
+if (require.main === module) {
+  testEmbedding()
+    .then((success) => {
+      if (success) {
+        console.log("\n✅ Ollama is working correctly!");
+        console.log("You can now use the search-ideas API.");
+      } else {
+        console.log("\n❌ Please ensure Ollama is running: ollama serve");
+      }
+      process.exit(success ? 0 : 1);
+    })
+    .catch((error) => {
+      console.error("Unexpected error:", error);
+      process.exit(1);
+    });
+}
+
+export { testEmbedding };


### PR DESCRIPTION
## 概要

uniteイベントのフラグ追加と、Ollama埋め込みテスト用スクリプトを新規追加しました。これにより、uniteイベントの制御や、Ollamaによるembedding生成の動作確認が容易になります。

## 主な変更点

- `crawledEvents.json`に`"unite": false`を追加
  - uniteイベントの有効／無効を管理可能に
- `src/scripts/testEmbedding.ts`を新規追加
  - OllamaAdapterを使ったembedding生成の動作確認ができるスクリプト
  - コマンドラインから実行し、Ollamaが正しく動作しているかを検証可能

ご確認よろしくお願いいたします。