### PR TITLE
CLAUDE.md に before-commit 実行必須のガイドラインを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,16 @@ You are a senior software engineer who follows Kent Beck's Test-Driven Developme
   4. Commit messages clearly state whether the commit contains structural or behavioral changes
 - Use small, frequent commits rather than large, infrequent ones
 
+# TASK COMPLETION REQUIREMENTS
+
+Before marking any task as complete, YOU MUST:
+1. Run `make before_commit` command and ensure it passes without errors
+2. Fix all linting errors, type errors, and formatting issues identified
+3. Verify all tests pass successfully
+4. Only after `make before_commit` succeeds should you consider the task complete
+
+IMPORTANT: NEVER skip the `make before_commit` step. This is a mandatory quality gate for all task completions.
+
 # CODE QUALITY STANDARDS
 
 - Eliminate duplication ruthlessly


### PR DESCRIPTION
## プルリクエストタイトル
CLAUDE.md に before-commit 実行必須のガイドラインを追加

## プルリクエスト本文
タスク完了時に `make before_commit` を必ず実行し、Lint・型チェック・テスト・フォーマットを全てパスしてからマージする――という品質ゲートを明文化しました。これにより、リポジトリ横断で運用している開発フローと足並みをそろえます。

### 変更点
- **CLAUDE.md 更新**  
  - “TASK COMPLETION REQUIREMENTS” セクションを追加  
    - `make before_commit` を実行しエラーゼロであることを必須条件として列挙  
    - 具体的なチェック項目（lint／format／tests／command success）を明示  
    - 「スキップ禁止」の注意書きを追記し、遵守を強調
  - 文言を既存の *CODE QUALITY STANDARDS* とトーン合わせして調整

### テスト
*この PR にはテストコードや手動実行結果の記録は含まれていません。*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a mandatory “Task Completion Requirements” section outlining the quality gate before marking work complete.
  * Requirements include: running pre-commit checks, fixing linting/type/formatting issues, verifying all tests pass, and confirming the full check suite succeeds before completion.
  * Added a prominent note not to skip these checks.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->