### PR TITLE
README: ドキュメント章の英語化と用語統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,20 +109,20 @@ curl http://localhost:3000/api/crawl
 - Qdrant: A vector database used for searching similar projects.
 - Ollama: A local LLM tool used to analyze ideas and generate improvement suggestions.
 
-## ドキュメント
+## Documentation
 
-詳細なドキュメントについては、以下をご参照ください。
+For detailed documentation, see the following:
 
-- **[API ドキュメント](docs/API.md)** - API エンドポイントの詳細仕様
-- **[アーキテクチャドキュメント](docs/ARCHITECTURE.md)** - システム設計とアーキテクチャ
-- **[開発者ガイド](docs/DEVELOPER_GUIDE.md)** - 開発環境構築とコーディング規約
-- **[トラブルシューティング](docs/TROUBLESHOOTING.md)** - よくある問題と解決方法
-- **[コンポーネントカタログ](docs/COMPONENTS.md)** - UI コンポーネントの使用方法
+- **[API Documentation](docs/API.md)** - Detailed specifications of API endpoints
+- **[Architecture](docs/ARCHITECTURE.md)** - System design and architecture
+- **[Developer Guide](docs/DEVELOPER_GUIDE.md)** - Development setup and coding conventions
+- **[Troubleshooting](docs/TROUBLESHOOTING.md)** - Common issues and solutions
+- **[Component Catalog](docs/COMPONENTS.md)** - UI component usage
 
-追加のドキュメントは以下のとおりです。
-- **[UX仕様](docs/UX_SPEC.md)** - ユーザーエクスペリエンス設計
-- **[MCP設定](docs/mcp-setup.md)** - MCP サーバーのセットアップ方法
-- **[自動クローリング設定](docs/auto-crawl-setup.md)** - データクローリングの設定
+Additional documents:
+- **[UX Spec](docs/UX_SPEC.md)** - User experience design
+- **[MCP Setup](docs/mcp-setup.md)** - How to set up the MCP server
+- **[Auto-Crawl Setup](docs/auto-crawl-setup.md)** - Data crawling configuration
 
 ## License
 


### PR DESCRIPTION
README: ドキュメント章の英語化と用語統一

## 概要
README.md の「ドキュメント」セクションを英語化し、リンク見出しや説明文の表記を英語に統一しました。プロジェクトの国際化と英語話者へのアクセシビリティ向上が目的です。

## 変更内容
- セクション見出しを「## ドキュメント」から「## Documentation」に変更
- 説明文を日本語から英語へ翻訳
- 各ドキュメントリンクの見出しを英語化
  - API ドキュメント → API Documentation
  - アーキテクチャドキュメント → Architecture
  - 開発者ガイド → Developer Guide
  - トラブルシューティング → Troubleshooting
  - コンポーネントカタログ → Component Catalog
- 追加ドキュメントの見出し・説明を英語化
  - UX仕様 → UX Spec
  - MCP設定 → MCP Setup
  - 自動クローリング設定 → Auto-Crawl Setup

対象ファイル:
- README.md（11 additions / 11 deletions）

## 背景・目的
- 英語圏のコントリビューター/ユーザーがREADMEから直接必要情報へアクセスできるようにする
- リポジトリ内ドキュメントの見出し・用語を英語で統一し可読性を向上

## 影響範囲
- README.md の表示のみ。コードやAPI仕様への影響はありません
- 既存のドキュメントファイルパスは変更していません（リンク切れなし）

## 動作確認
- 各リンク（docs/*.md）が正しく開けることを確認
- セクション見出しのアンカーリンクが機能することを確認

## 補足
- 日本語版の案内が必要な場合は、READMEに「言語切替（日本語/English）」の導線追加を今後検討可能です

## チェックリスト
- [x] 文言・用語の英語表記を統一
- [x] 既存ドキュメントへのリンク動作確認
- [x] 破壊的変更なし

## 関連
- ブランチ: feature/english
- コミット: add english