### PR TITLE
bugfix: fail-to-read の解消と診断機能の追加（Qdrant互換性設定/バリデーション緩和/LLM診断UI・API）

### DIFF
--- a/mcp-server/src/qdrantClient.ts
+++ b/mcp-server/src/qdrantClient.ts
@@ -120,6 +120,7 @@ export class QdrantHandler {
     this.client = new QdrantClient({
       url: this.env.QD_URL,
       apiKey: this.env.QD_API_KEY,
+      checkCompatibility: false,
     });
   }
 

--- a/src/__tests__/api/improve-idea.test.ts
+++ b/src/__tests__/api/improve-idea.test.ts
@@ -165,18 +165,28 @@ describe("/api/improve-idea", () => {
     });
   });
 
-  it("should return 400 when similarProjects is missing", async () => {
+  it("should successfully process idea when similarProjects is missing", async () => {
+    const mockResponse = "Improved idea based on expert knowledge";
+    const idea = "My brilliant idea";
+
+    // Mock the parseHtmlWithLLM function to return success
+    vi.mocked(parseHtmlWithLLM).mockResolvedValue(mockResponse);
+
     const { req, res } = createMockRequestResponse("POST", {
-      idea: "My brilliant idea",
+      idea,
     });
 
     await handler(req, res);
 
-    expect((res as any)._getStatusCode()).toBe(400);
-    expect(JSON.parse((res as any)._getData())).toEqual({
-      error: "入力内容に問題があります。内容を確認してください。",
-      type: "VALIDATION_ERROR",
-      timestamp: expect.any(String),
+    expect((res as any)._getStatusCode()).toBe(200);
+    const responseData = JSON.parse((res as any)._getData());
+    expect(responseData).toEqual({
+      improvedIdea: mockResponse,
+      metadata: {
+        processingTime: expect.any(Number),
+        ideaLength: idea.length,
+        similarProjectsAnalyzed: 0, // Should be 0 when missing
+      },
     });
   });
 

--- a/src/adapters/__tests__/qdrant.adapter.test.ts
+++ b/src/adapters/__tests__/qdrant.adapter.test.ts
@@ -68,6 +68,7 @@ describe("QdrantAdapter", () => {
         url: "http://localhost:6333",
         apiKey: "",
         timeout: undefined,
+        checkCompatibility: false,
       });
     });
 
@@ -84,6 +85,7 @@ describe("QdrantAdapter", () => {
         url: "http://custom:6333",
         apiKey: "test-key",
         timeout: 5000,
+        checkCompatibility: false,
       });
     });
 
@@ -106,6 +108,7 @@ describe("QdrantAdapter", () => {
         url: "http://env-url:6333",
         apiKey: "env-api-key",
         timeout: undefined,
+        checkCompatibility: false,
       });
     });
 
@@ -133,6 +136,7 @@ describe("QdrantAdapter", () => {
         url: "http://config-url:6333",
         apiKey: "config-api-key",
         timeout: undefined,
+        checkCompatibility: false,
       });
     });
   });

--- a/src/adapters/qdrant.adapter.ts
+++ b/src/adapters/qdrant.adapter.ts
@@ -49,6 +49,7 @@ export class QdrantAdapter implements VectorDBClient {
       url,
       apiKey,
       timeout: config?.timeout,
+      checkCompatibility: false,
     });
   }
 

--- a/src/lib/qdrantHandler.test.ts
+++ b/src/lib/qdrantHandler.test.ts
@@ -124,6 +124,7 @@ describe("QdrantHandler", () => {
       expect(QdrantClient).toHaveBeenCalledWith({
         url: "http://test-qdrant:6333",
         apiKey: "test-api-key",
+        checkCompatibility: false,
       });
     });
 
@@ -142,6 +143,7 @@ describe("QdrantHandler", () => {
       expect(QdrantClient).toHaveBeenCalledWith({
         url: "http://localhost:6333",
         apiKey: "",
+        checkCompatibility: false,
       });
     });
 

--- a/src/lib/qdrantHandler.ts
+++ b/src/lib/qdrantHandler.ts
@@ -45,6 +45,7 @@ export class QdrantHandler {
       this.client = new QdrantClient({
         url: env.QD_URL,
         apiKey: env.QD_API_KEY,
+        checkCompatibility: false,
       });
     } else {
       // Legacy constructor pattern for backward compatibility
@@ -52,6 +53,7 @@ export class QdrantHandler {
       this.client = new QdrantClient({
         url: env.QD_URL,
         apiKey: env.QD_API_KEY,
+        checkCompatibility: false,
       });
       // Initialize with default adapters
       this.embeddingProvider = EmbeddingFactory.create();

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -25,8 +25,8 @@ export const ImproveIdeaRequestSchema = z.object({
   idea: IdeaSchema,
   similarProjects: z
     .array(SimilarProjectSchema)
-    .min(1, "少なくとも1つの類似プロジェクトが必要です")
-    .max(20, "類似プロジェクトは20件以内にしてください"),
+    .max(20, "類似プロジェクトは20件以内にしてください")
+    .default([]),
 });
 
 // Generate idea from prize brief (simple version)

--- a/src/pages/api/debug/llm-status.ts
+++ b/src/pages/api/debug/llm-status.ts
@@ -1,0 +1,113 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import ollama from "ollama";
+import Groq from "groq-sdk";
+import { isProduction as isProdEnv } from "@/lib/env";
+import logger from "@/lib/logger";
+
+// Ensure Node.js runtime on Vercel/Next with extended timeout
+export const config = {
+  runtime: "nodejs",
+  maxDuration: 60, // 1 minute should be sufficient for diagnostic checks
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  // Only allow GET requests
+  if (req.method !== "GET") {
+    return res.status(405).json({
+      error: "Method Not Allowed",
+      message: "Only GET method is allowed",
+    });
+  }
+
+  const isProduction = isProdEnv();
+  const diagnostics: any = {
+    environment: process.env.NODE_ENV,
+    isProduction,
+    timestamp: new Date().toISOString(),
+    llmConfig: {
+      ollamaModel: process.env.OLLAMA_MODEL || "llama3.1",
+      groqModel: process.env.GROQ_MODEL || "llama3-8b-8192",
+      hasGroqKey: !!process.env.GROQ_API_KEY,
+    },
+  };
+
+  try {
+    if (!isProduction) {
+      // Test Ollama connection
+      try {
+        logger.info("Testing Ollama connection...");
+        const models = await ollama.list();
+        const targetModel = process.env.OLLAMA_MODEL || "llama3.1";
+        const modelExists = models.models.some((m) =>
+          m.name.includes(targetModel),
+        );
+
+        diagnostics.ollama = {
+          status: "connected",
+          availableModels: models.models.map((m) => m.name),
+          targetModel,
+          targetModelExists: modelExists,
+          modelsCount: models.models.length,
+        };
+
+        if (!modelExists) {
+          diagnostics.ollama.warning = `Target model ${targetModel} not found. Available models: ${models.models.map((m) => m.name).join(", ")}`;
+        }
+      } catch (error) {
+        diagnostics.ollama = {
+          status: "error",
+          error: error instanceof Error ? error.message : "Unknown error",
+          suggestion:
+            "Make sure Ollama is running and accessible. Try: ollama serve",
+        };
+      }
+    } else {
+      // Test Groq connection
+      try {
+        if (!process.env.GROQ_API_KEY) {
+          throw new Error("GROQ_API_KEY environment variable is not set");
+        }
+
+        const groqClient = new Groq({ apiKey: process.env.GROQ_API_KEY });
+
+        // Simple test request
+        const testResponse = await groqClient.chat.completions.create({
+          messages: [
+            { role: "user", content: "Hello, please respond with 'OK'" },
+          ],
+          model: process.env.GROQ_MODEL || "llama3-8b-8192",
+          max_tokens: 10,
+        });
+
+        diagnostics.groq = {
+          status: "connected",
+          model: process.env.GROQ_MODEL || "llama3-8b-8192",
+          testResponse:
+            testResponse.choices[0]?.message?.content || "No response",
+        };
+      } catch (error) {
+        diagnostics.groq = {
+          status: "error",
+          error: error instanceof Error ? error.message : "Unknown error",
+          suggestion:
+            "Check GROQ_API_KEY environment variable and network connectivity",
+        };
+      }
+    }
+
+    res.status(200).json({
+      success: true,
+      diagnostics,
+    });
+  } catch (error) {
+    logger.error("LLM status check failed:", error);
+    res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+      diagnostics,
+    });
+  }
+}

--- a/src/pages/api/generate-idea.ts
+++ b/src/pages/api/generate-idea.ts
@@ -17,7 +17,10 @@ import {
   createValidationError,
 } from "@/lib/errorHandler";
 
-export const config = { runtime: "nodejs" };
+export const config = {
+  runtime: "nodejs",
+  maxDuration: 300, // 5 minutes for Pro/Enterprise plans, 10 seconds for Hobby
+};
 
 export default async function handler(
   req: NextApiRequest,

--- a/src/pages/api/generate-winning-idea.ts
+++ b/src/pages/api/generate-winning-idea.ts
@@ -17,7 +17,7 @@ import { GenerateWinningIdeaRequestSchema } from "@/lib/validation";
 // Ensure Node.js runtime
 export const config = {
   runtime: "nodejs",
-  maxDuration: 60, // 60秒のタイムアウト（アイデア生成は時間がかかる）
+  maxDuration: 300, // 5 minutes for Pro/Enterprise plans (AI generation is time-consuming)
 };
 
 export default async function handler(

--- a/src/pages/api/improve-idea.ts
+++ b/src/pages/api/improve-idea.ts
@@ -19,9 +19,10 @@ import {
   createRateLimitError,
 } from "@/lib/rateLimit";
 
-// Ensure Node.js runtime on Vercel/Next
+// Ensure Node.js runtime on Vercel/Next with extended timeout
 export const config = {
   runtime: "nodejs",
+  maxDuration: 300, // 5 minutes for Pro/Enterprise plans, 10 seconds for Hobby
 };
 
 export default async function handler(
@@ -77,7 +78,7 @@ export default async function handler(
       throw createValidationError(validation.error);
     }
 
-    const { idea: rawIdea, similarProjects } = validation.data;
+    const { idea: rawIdea, similarProjects = [] } = validation.data;
 
     // Sanitize the idea input
     const idea = sanitizeString(rawIdea);
@@ -99,35 +100,71 @@ export default async function handler(
       ip: req.headers["x-forwarded-for"] || req.socket.remoteAddress,
     });
 
-    const prompt = `
-      あなたは、ハッカソンで何度も勝利を収めた伝説のスーパーエンジニアであり、Web3領域の最前線で活躍しています。クリプトプロダクト設計においては、ネットワーク効果や正の外部性、Fat Protocol理論、Hyperstructureの概念を深く理解し、それらを活用したプロダクト開発に卓越しています。私のアイデアを元に、ハッカソンで勝利するための具体的な改善提案をお願いします。提案は、クリプトプロダクト設計の重要な要素であるネットワーク効果、正の外部性、Fat Protocol理論を最大限に活用し、以下のハッカソン評価基準を満たすことを目指します。
-      特に、次の審査基準に基づいてアイデアをブラッシュアップしてください：
-      1. 技術的な複雑さ: 問題の解決アプローチがどれほど技術的に優れているか？
-      2. 独創性: このアイデアがどれほど革新的で、新しい問題に取り組んでいるか？
-      3. 実用性: このアイデアが実際にどれほど完成しており、実用的か？
-      4. 使いやすさ: ユーザーにとってこのプロダクトがどれほど使いやすいか？
-      5. 驚きの要素: このアイデアが審査員に感動や驚きを与えるか？
+    const prompt =
+      sanitizedSimilarProjects.length > 0
+        ? `
+        あなたは、ハッカソンで何度も勝利を収めた伝説のスーパーエンジニアであり、Web3領域の最前線で活躍しています。クリプトプロダクト設計においては、ネットワーク効果や正の外部性、Fat Protocol理論、Hyperstructureの概念を深く理解し、それらを活用したプロダクト開発に卓越しています。私のアイデアを元に、ハッカソンで勝利するための具体的な改善提案をお願いします。提案は、クリプトプロダクト設計の重要な要素であるネットワーク効果、正の外部性、Fat Protocol理論を最大限に活用し、以下のハッカソン評価基準を満たすことを目指します。
+        特に、次の審査基準に基づいてアイデアをブラッシュアップしてください：
+        1. 技術的な複雑さ: 問題の解決アプローチがどれほど技術的に優れているか？
+        2. 独創性: このアイデアがどれほど革新的で、新しい問題に取り組んでいるか？
+        3. 実用性: このアイデアが実際にどれほど完成しており、実用的か？
+        4. 使いやすさ: ユーザーにとってこのプロダクトがどれほど使いやすいか？
+        5. 驚きの要素: このアイデアが審査員に感動や驚きを与えるか？
 
-      以下の新しいアイデアについて、過去の類似プロジェクトと比較し、どのプロジェクトが似ているか、そしてなぜ似ているのかを説明してください。またアイデアへのフィードバックを提供してください。
+        以下の新しいアイデアについて、過去の類似プロジェクトと比較し、どのプロジェクトが似ているか、そしてなぜ似ているのかを説明してください。またアイデアへのフィードバックを提供してください。
 
-      **アイデア**: ${idea}
+        **アイデア**: ${idea}
 
-      **類似プロジェクト**:
-      ${sanitizedSimilarProjects.map((project: any) => `- ${project.title}: ${project.description}`).join("\n")}
+        **類似プロジェクト**:
+        ${sanitizedSimilarProjects.map((project: any) => `- ${project.title}: ${project.description}`).join("\n")}
 
-      提案されたアイデアと類似プロジェクトを比較し、以下の形式で似ているプロジェクトの名前と類似点を説明してください。
+        提案されたアイデアと類似プロジェクトを比較し、以下の形式で似ているプロジェクトの名前と類似点を説明してください。
 
-      [出力形式]
-      - プロジェクト名: {プロジェクト名}
-        アイデアへのフィードバック: {アイデアを改良するための説明}
-        類似点: {類似点の説明}
+        [出力形式]
+        - プロジェクト名: {プロジェクト名}
+          アイデアへのフィードバック: {アイデアを改良するための説明}
+          類似点: {類似点の説明}
 
-      日本語で説明してください。
-    `;
+        日本語で説明してください。
+      `
+        : `
+        あなたは、ハッカソンで何度も勝利を収めた伝説のスーパーエンジニアであり、Web3領域の最前線で活躍しています。クリプトプロダクト設計においては、ネットワーク効果や正の外部性、Fat Protocol理論、Hyperstructureの概念を深く理解し、それらを活用したプロダクト開発に卓越しています。私のアイデアを元に、ハッカソンで勝利するための具体的な改善提案をお願いします。提案は、クリプトプロダクト設計の重要な要素であるネットワーク効果、正の外部性、Fat Protocol理論を最大限に活用し、以下のハッカソン評価基準を満たすことを目指します。
+        特に、次の審査基準に基づいてアイデアをブラッシュアップしてください：
+        1. 技術的な複雑さ: 問題の解決アプローチがどれほど技術的に優れているか？
+        2. 独創性: このアイデアがどれほど革新的で、新しい問題に取り組んでいるか？
+        3. 実用性: このアイデアが実際にどれほど完成しており、実用的か？
+        4. 使いやすさ: ユーザーにとってこのプロダクトがどれほど使いやすいか？
+        5. 驚きの要素: このアイデアが審査員に感動や驚きを与えるか？
+
+        以下のアイデアについて、ハッカソンで勝利するための改善提案を提供してください。類似プロジェクトが見つからなかったため、あなたの専門知識を活用して革新的な改良アイデアを提案してください。
+
+        **アイデア**: ${idea}
+
+        [出力形式]
+        **改良されたアイデア**
+        1. **技術的改善点**: {技術面での具体的な改善提案}
+        2. **独創性の向上**: {オリジナリティを高めるための提案}
+        3. **実用性の強化**: {実装可能性を高めるアプローチ}
+        4. **UX/UI改善**: {使いやすさを向上させる提案}
+        5. **驚きの要素**: {審査員にインパクトを与える要素}
+        6. **技術スタック**: {推奨する技術構成}
+        7. **MVP実装計画**: {最小限の実装プラン}
+
+        日本語で詳細に説明してください。
+      `;
+
+    logger.info("About to call parseHtmlWithLLM", {
+      ideaLength: idea.length,
+      promptLength: prompt.length,
+      environment: process.env.NODE_ENV,
+      ollamaModel: process.env.OLLAMA_MODEL || "llama3.1",
+      hasGroqKey: !!process.env.GROQ_API_KEY,
+    });
 
     const response = await parseHtmlWithLLM(idea, prompt);
 
     if (!response || typeof response !== "string") {
+      logger.error("Invalid response from LLM parser", { response });
       throw new Error("Invalid response from LLM parser");
     }
 

--- a/src/scripts/removeDuplicates.ts
+++ b/src/scripts/removeDuplicates.ts
@@ -24,6 +24,7 @@ async function removeDuplicates() {
   const client = new QdrantClient({
     url: env.QD_URL,
     apiKey: env.QD_API_KEY,
+    checkCompatibility: false,
   });
 
   try {

--- a/src/scripts/testQdrantConnection.ts
+++ b/src/scripts/testQdrantConnection.ts
@@ -11,6 +11,7 @@ async function testConnection() {
     url: env.QD_URL,
     apiKey: env.QD_API_KEY,
     timeout: 10000, // 10秒のタイムアウト
+    checkCompatibility: false,
   });
 
   try {


### PR DESCRIPTION
タイトル: bugfix: fail-to-read の解消と診断機能の追加（Qdrant互換性設定/バリデーション緩和/LLM診断UI・API）

概要:
一部環境で発生していた「fail to read」系エラーを解消し、LLM周辺の障害切り分けを容易にする診断 API と UI を追加しました。類似プロジェクトが取得できないケースでも改善生成が継続できるようバリデーションとプロンプトを見直し、API の実行タイムアウト（maxDuration）を延長して安定性を高めています。

背景・原因:
- Qdrant クライアントの互換性チェックが一部環境で接続・メソッド呼び出し失敗の一因に。
- improve-idea 系エンドポイントで similarProjects 未指定時に 400 を返しユーザー操作を阻害。
- LLM 側の接続・モデル設定の問題が UI から見えづらく、障害切り分けが困難。

主な変更点:
- Qdrant 接続安定化
  - すべての QdrantClient 生成箇所に checkCompatibility: false を明示。 (mcp-server/src/qdrantClient.ts, adapters, lib, scripts)
  - 対応する単体テストを更新。
- バリデーション緩和と既定値
  - similarProjects を必須→任意に変更し、既定値 [] を付与。上限 20 件は維持。 (src/lib/validation.ts)
- API の安定化
  - Next API の maxDuration を延長（最大 300 秒）し長時間生成/ストリーミングを許容。 (generate-idea.ts, generate-winning-idea.ts, improve-idea.ts, improve-idea-stream.ts)
  - improve-idea / improve-idea-stream で similarProjects 未提供時でも、専門知識ベースの改善プロンプトに自動フォールバック。
  - LLM 応答の型チェック/エラーログを強化。
- 診断機能の追加
  - 新規エンドポイント /api/debug/llm-status を追加。開発: Ollama、本番: Groq の接続チェック・モデル状況を返却。 (src/pages/api/debug/llm-status.ts)
  - IdeaForm に診断 UI（System Status ボタン、Ollama/Groq の状態表示・警告/提案メッセージ）を追加。 (src/components/IdeaForm.tsx)
- UX/メッセージ改善
  - 類似プロジェクト件数に応じた進行メッセージ、未検出時のフォールバック明示、API エラー詳細のログ出力など。
- テスト更新
  - similarProjects 未指定時の 200 応答・メタデータ検証等のケースを追加。 (各種 test.ts)

変更範囲:
- 15 files changed, +412 / -47
- 主要ファイル: IdeaForm.tsx（UI/診断大幅追加）, improve-idea.ts / improve-idea-stream.ts（プロンプト分岐・安定化）, llm-status.ts（新規）

ユーザー影響:
- 類似プロジェクトが見つからない/未入力でも改善アイデアが生成されるように。
- LLM 側の不調（接続/モデル未配置/API Key 未設定など）を UI から即時把握可能。
- Qdrant 周りの接続/互換性による読み取り失敗の発生確率を低減。

動作確認:
- 開発環境で Ollama 稼働時に診断 API が接続/モデル存在を返すことを確認。
- 本番相当で GROQ_API_KEY 設定時、簡易チャット疎通が成功することを確認。
- similarProjects 未提供時の improve-idea/improve-idea-stream が 200 を返し、フォールバック・プロンプトで改善文を出力することを確認。
- Qdrant 接続が checkCompatibility: false で安定することをスクリプト/アダプタ/サーバで確認。

テスト:
- バリデーション変更に伴うテスト更新（未指定→成功、メタデータ検証）。
- QdrantClient 生成引数の期待値更新。
- 追加のユニット/統合テストは継続拡充予定。

破壊的変更:
- なし（既存 API 契約は後方互換／バリデーションは緩和方向）。

フォローアップ（任意）:
- 診断 API のレスポンスを観測基盤に連携（ヘルスチェック/アラート）。
- LLM 推論のリトライ/フェイルオーバー戦略（Ollama↔Groq 切替）強化。
- 類似プロジェクト探索のタイムアウト/部分結果返却の洗練。

ラベル提案:
- bug
- enhancement
- dx