### PR TITLE
Add: newyork2025 フラグを crawledEvents.json に追加

### DIFF
--- a/crawledEvents.json
+++ b/crawledEvents.json
@@ -1,4 +1,5 @@
 {
+  "newyork2025": false,
   "unite": false,
   "cannes": false,
   "prague": false,


### PR DESCRIPTION
タイトル:
Add: newyork2025 フラグを crawledEvents.json に追加

概要:
New York 2025 のイベント対応に向けて、イベントフラグ newyork2025 を crawledEvents.json に追加しました。初期値は false で、データ準備や機能切り替え時に利用する前提です。現時点では動作変更はありません。

変更内容:
- **JSON更新:** crawledEvents.json に "newyork2025": false を追加
- **差分:** 1ファイル、1行の追加のみ（削除なし）
- **関連キー:** 既存の unite / cannes / prague と同様のパターンで管理

目的/背景:
- **将来拡張:** New York 2025 イベントの有効化フラグを先行で用意
- **安全なデフォルト:** 既定値を false にすることで、未準備状態での機能露出を防止
- **一貫性:** 他イベントフラグと同様のスキーマで統一

動作への影響:
- 現時点では機能の有効化は行っておらず、ランタイム動作に変更はありません
- フラグ参照箇所（後続PR予定）でのみ挙動が変わる予定です

テスト/確認:
- **JSON検証:** 構文チェック（lint/フォーマット）に合格
- **ビルド/起動:** アプリ起動確認（エラーなし）
- **後続対応:** フラグ参照のユニットテストは別PRで追加予定

リスクと懸念:
- **低リスク:** データ追加のみで既存ロジックには未接続
- **命名衝突:** 他キーとの重複なし（newyork2025 は新規）

ロールアウト計画:
- 現状は配置のみ
- データ投入/機能切替は別PRで段階的に有効化

関連Issue:
- なし（必要であれば追記）
- 例: Closes #123

チェックリスト:
- [x] JSON 形式の妥当性確認
- [x] 既存キーとの整合性確認
- [x] ビルド/起動確認
- [ ] フラグ参照テストの追加（後続PR）

レビュー観点:
- キー命名（newyork2025）の妥当性
- イベントフラグの管理方針の一貫性
- 後続PRでの参照箇所設計（トグルの導線）